### PR TITLE
feat: added pointer hover on clickable, outline on hover

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
 import ReactMapGL, {
   Source,
@@ -7,12 +7,7 @@ import ReactMapGL, {
   MapEvent
 } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import {
-  FeatureCollection,
-  Feature,
-  Geometry,
-  GeoJsonProperties
-} from 'geojson';
+import { FeatureCollection } from 'geojson';
 
 interface MapProps {
   latitude: number;
@@ -39,15 +34,17 @@ const Map: React.FC<MapProps> = ({
     zoom: 16
   });
 
-  const [hoveredFeature, setHoveredFeature] = useState<
-    Feature<Geometry, GeoJsonProperties>
-  >({} as Feature);
+  const [hoveredFeatures, setHoveredFeatures] = useState<FeatureCollection>({
+    type: 'FeatureCollection',
+    features: []
+  } as FeatureCollection);
 
-  const handleHover = useCallback(({ features }: MapEvent) => {
-    setHoveredFeature(
-      Array.isArray(features) && features.length > 0 ? features[0] : undefined
-    );
-  }, []);
+  const handleHover = ({ features }: MapEvent) => {
+    setHoveredFeatures({
+      type: 'FeatureCollection',
+      features
+    } as FeatureCollection);
+  };
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   return (
@@ -65,32 +62,27 @@ const Map: React.FC<MapProps> = ({
         }
       >
         {data &&
-          data.map((datum, i) => {
-            const key = `map=src-${i}`;
-            return (
-              <Source id={key} key={key} type='geojson' data={datum}>
-                <Layer
-                  id='layerFill'
-                  type='fill'
-                  paint={{
-                    'fill-color': '#A150F2'
-                  }}
-                />
-              </Source>
-            );
-          })}
-        {hoveredFeature ? (
-          <Source id='hovered' type='geojson' data={hoveredFeature}>
-            <Layer
-              id='layerLine'
-              type='line'
-              paint={{
-                'line-width': 2,
-                'line-color': '#2ECC71'
-              }}
-            />
-          </Source>
-        ) : null}
+          data.map((datum, i) => (
+            <Source key={`map=src-${i}`} type='geojson' data={datum}>
+              <Layer
+                id='layerFill'
+                type='fill'
+                paint={{
+                  'fill-color': '#A150F2'
+                }}
+              />
+            </Source>
+          ))}
+        <Source id='hovered' type='geojson' data={hoveredFeatures}>
+          <Layer
+            id='layerLine'
+            type='line'
+            paint={{
+              'line-width': 2,
+              'line-color': '#2ECC71'
+            }}
+          />
+        </Source>
       </ReactMapGL>
     </MapContainer>
   );

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -34,12 +34,13 @@ const Map: React.FC<MapProps> = ({
     zoom: 16
   });
 
-  const [hoverSource, setHoverSource] = useState('');
+  const [hoveredFeature, setHoveredFeature] = useState(undefined);
 
   const handleHover = useCallback(({ features }: MapEvent) => {
-    setHoverSource(features && features.length > 0 ? features[0].source : '');
+    setHoveredFeature(
+      Array.isArray(features) && features.length > 0 ? features[0] : ''
+    );
   }, []);
-  const handleCursor = () => (hoverSource ? 'pointer' : 'grab');
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   return (
@@ -52,7 +53,9 @@ const Map: React.FC<MapProps> = ({
         onViewportChange={setViewport}
         onClick={displayFeature}
         onHover={handleHover}
-        getCursor={handleCursor}
+        interactiveLayerIds={
+          Array.isArray(data) && data.length > 0 ? ['layerFill'] : []
+        }
       >
         {data &&
           data.map((datum, i) => {
@@ -66,17 +69,21 @@ const Map: React.FC<MapProps> = ({
                     'fill-color': '#A150F2'
                   }}
                 />
-                <Layer
-                  id='layerLine'
-                  type='line'
-                  paint={{
-                    'line-width': 4,
-                    'line-color': hoverSource === key ? '#5e219c' : '#A150F2'
-                  }}
-                />
               </Source>
             );
           })}
+        {hoveredFeature ? (
+          <Source id='hovered' type='geojson' data={hoveredFeature}>
+            <Layer
+              id='layerLine'
+              type='line'
+              paint={{
+                'line-width': 2,
+                'line-color': '#2ECC71'
+              }}
+            />
+          </Source>
+        ) : null}
       </ReactMapGL>
     </MapContainer>
   );

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -7,7 +7,12 @@ import ReactMapGL, {
   MapEvent
 } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import { FeatureCollection } from 'geojson';
+import {
+  FeatureCollection,
+  Feature,
+  Geometry,
+  GeoJsonProperties
+} from 'geojson';
 
 interface MapProps {
   latitude: number;
@@ -34,11 +39,13 @@ const Map: React.FC<MapProps> = ({
     zoom: 16
   });
 
-  const [hoveredFeature, setHoveredFeature] = useState(undefined);
+  const [hoveredFeature, setHoveredFeature] = useState<
+    Feature<Geometry, GeoJsonProperties>
+  >({} as Feature);
 
   const handleHover = useCallback(({ features }: MapEvent) => {
     setHoveredFeature(
-      Array.isArray(features) && features.length > 0 ? features[0] : ''
+      Array.isArray(features) && features.length > 0 ? features[0] : undefined
     );
   }, []);
 

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import styled from 'styled-components';
 import ReactMapGL, {
   Source,
@@ -34,6 +34,13 @@ const Map: React.FC<MapProps> = ({
     zoom: 16
   });
 
+  const [hoverSource, setHoverSource] = useState('');
+
+  const handleHover = useCallback(({ features }: MapEvent) => {
+    setHoverSource(features && features.length > 0 ? features[0].source : '');
+  }, []);
+  const handleCursor = () => (hoverSource ? 'pointer' : 'grab');
+
   const containerRef = useRef<HTMLDivElement | null>(null);
   return (
     <MapContainer ref={containerRef}>
@@ -44,19 +51,32 @@ const Map: React.FC<MapProps> = ({
         height='100%'
         onViewportChange={setViewport}
         onClick={displayFeature}
+        onHover={handleHover}
+        getCursor={handleCursor}
       >
         {data &&
-          data.map((datum, i) => (
-            <Source key={`map=src-${i}`} type='geojson' data={datum}>
-              <Layer
-                id='test'
-                type='fill'
-                paint={{
-                  'fill-color': '#A150F2'
-                }}
-              />
-            </Source>
-          ))}
+          data.map((datum, i) => {
+            const key = `map=src-${i}`;
+            return (
+              <Source id={key} key={key} type='geojson' data={datum}>
+                <Layer
+                  id='layerFill'
+                  type='fill'
+                  paint={{
+                    'fill-color': '#A150F2'
+                  }}
+                />
+                <Layer
+                  id='layerLine'
+                  type='line'
+                  paint={{
+                    'line-width': 4,
+                    'line-color': hoverSource === key ? '#5e219c' : '#A150F2'
+                  }}
+                />
+              </Source>
+            );
+          })}
       </ReactMapGL>
     </MapContainer>
   );


### PR DESCRIPTION
Closes #17, #18, and #19.

The map now shows a "pointer" cursor when hovering over valid features. Our added features will also have an outline that changes colour whenever the element is hovered over.

**Preview:**

![5rl8aXPvkI](https://user-images.githubusercontent.com/47393759/127559326-e939fda8-0006-40a0-8f1e-9c3e3a008742.gif)

**Comments:**

A side effect of the cursor change is that it also sees buildings, roads, parks, etc. as valid features of the map. I can think of a way to restrict this to only our added features by using the `map=src-x` identifier. Let me know if this is want we want 😊

The outline is an additional line layer that is always visible (mapbox complained when this was dynamically included/excluded) but shifts colour based on hover. I looked into `feature-state` which would have been much nicer but I could not get the `hover` state to toggle. Looking into the `react-mapbox-gl` package, I found [issue #652](https://github.com/alex3165/react-mapbox-gl/issues/652) amongst a few others asking about the same thing. I'll have to look more if we want to implement the outline in this fashion.
